### PR TITLE
not include scope in oauth2client class

### DIFF
--- a/dj_rest_auth/registration/serializers.py
+++ b/dj_rest_auth/registration/serializers.py
@@ -118,8 +118,6 @@ class SocialLoginSerializer(serializers.Serializer):
                     _('Define client_class in view'),
                 )
 
-            provider = adapter.get_provider()
-            scope = provider.get_scope_from_request(request)
             client = self.client_class(
                 request,
                 app.client_id,
@@ -127,7 +125,6 @@ class SocialLoginSerializer(serializers.Serializer):
                 adapter.access_token_method,
                 adapter.access_token_url,
                 self.callback_url,
-                scope,
                 scope_delimiter=adapter.scope_delimiter,
                 headers=adapter.headers,
                 basic_auth=adapter.basic_auth,


### PR DESCRIPTION
solved: OAuth2Client.__init__() got multiple values for argument 'scope_delimiter'